### PR TITLE
tsmodal: fix js issues and increase z-index

### DIFF
--- a/sphinx_tcmodal/assets/tcmodal.css
+++ b/sphinx_tcmodal/assets/tcmodal.css
@@ -8,7 +8,7 @@
     position: fixed;
     top: 0;
     width: 100%;
-    z-index: 1;
+    z-index: 100;
 }
 
 .tcmodal-content {

--- a/sphinx_tcmodal/assets/tcmodal.js
+++ b/sphinx_tcmodal/assets/tcmodal.js
@@ -2,7 +2,6 @@ function tcmodal_eval(group_id) {
     var checkboxes = document.querySelectorAll("[id^='checkbox-" + group_id + "']");
     var allchecked = true;
     checkboxes.forEach((element) => {
-        console.log(element);
         if (element.checked !== true) allchecked = false;
     });
 
@@ -14,7 +13,7 @@ function tcmodal_eval(group_id) {
 function tcmodal(group_id) {
     var modal = document.getElementById(group_id);
 
-    if (modal.style.display == "none") {
+    if (modal.style.display == "none" || ! modal.style.display ) {
         modal.style.display = "inline";
     } else {
         modal.style.display = "none";


### PR DESCRIPTION
display=none is returned as a None object not as a string, hence we need to probe for that too, otherwise it would take two click for the modal to appear.

Also increase the z-index of the modal to 100, to really be on top of everything