### PR TITLE
simpleswitch: allow parsing of desc

### DIFF
--- a/docs/images/simpleswitch-test4-description.md.jinja
+++ b/docs/images/simpleswitch-test4-description.md.jinja
@@ -1,0 +1,14 @@
+This is a Jinja template text in markdown.
+
+With a [link](example.com)
+
+and
+
+- bullet
+- point
+- list
+
+and template code you shouldn't see in the rendered docs...
+{% if ip %}
+Inivisble block
+{% endif %}

--- a/docs/images/simpleswitch-test4_1.0.bb
+++ b/docs/images/simpleswitch-test4_1.0.bb
@@ -1,0 +1,4 @@
+DESCRIPTION = "${@oe.utils.read_file('${THISDIR}/${BPN}-description.md.jinja')}"
+
+SIMPLESWITCH_PICTURE = "file://recipes-core/images/_pictures/simpleswitch-hello-world-shell.jpg"
+SIMPLESWITCH_CATEGORIES = "shell demo terminal"

--- a/docs/images/simpleswitch-test5_1.0.bb
+++ b/docs/images/simpleswitch-test5_1.0.bb
@@ -1,0 +1,5 @@
+DESCRIPTION = "${@oe.utils.read_file('${THISDIR}/not-existing-description.md.jinja')}"
+SUMMARY = "This is the summary fallback of description"
+
+SIMPLESWITCH_PICTURE = "file://recipes-core/images/_pictures/simpleswitch-hello-world-shell.jpg"
+SIMPLESWITCH_CATEGORIES = "shell demo terminal"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Jinja2 ~= 3.1
 m2r2 ~= 0.3
-oelint-parser ~= 6.4
+oelint-parser ~= 8.8
 pydata-sphinx-theme ~= 0.15
 requests ~= 2.32
 sphinx ~= 8.1

--- a/sphinx_simpleswitch/__init__.py
+++ b/sphinx_simpleswitch/__init__.py
@@ -181,6 +181,8 @@ class SimpleSwitchContainer(SphinxDirective):
         _stash.AddFile(file)
         data['description'] = extract(_stash, 'DESCRIPTION')
         data['summary'] = extract(_stash, 'SUMMARY')
+        if not data['description']:
+            data['description'] = data['summary'] or ''
         data['categories'] = [x for x in extract(
             _stash, 'SIMPLESWITCH_CATEGORIES').split(' ') if x]
         return data


### PR DESCRIPTION
from file or fallback to SUMMARY.
This is enabled by using a newer oelint-parser.

Add examples to illustrate the changes